### PR TITLE
adds .zenodo.json draft to adapt

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,56 @@
+{
+    "license": "CC0-1.0",
+    "contributors": [
+        {
+            "name": "Belle, Anna",
+            "type": "Annotator",
+            "orcid": "0000-0000-0000-0000"
+        },
+        {
+            "name": "Daraud, Christine",
+            "type": "DataCurator",
+            "orcid": "0000-0000-0000-0000"
+        },
+        {
+            "name": "Fuhrmann, Erna",
+            "type": "DataCollector",
+            "orcid": "0000-0000-0000-0000"
+        }
+    ],
+    "title": "Johann Balthasar Rein (1714–1794) – Vierstimmig Choralbuch (A chorale corpus)",
+    "keywords": [
+        "music research",
+        "music theory",
+        "music analysis",
+        "music history",
+        "corpus studies",
+        "corpora",
+        "multimodal dataset",
+        "symbolic dataset",
+        "scores",
+        "chorales"
+    ],
+    "upload_type": "dataset",
+    "version": "v2.1",
+    "publication_date": "2025-09-30",
+    "creators": [
+        {
+            "name": "Gerhardt, Kirsten",
+            "affiliation": "Christian-Albrechts-Universität zu Kiel"
+        }
+    ],
+    "access_right": "open",
+    "related_identifiers": [
+        {
+            "scheme": "url",
+            "identifier": "https://github.com/Chorale-Corpus/Rein_JB/tree/v2.1",
+            "relation": "references"
+        },
+        {
+            "scheme": "doi",
+            "identifier": "10.5281/zenodo.17229783",
+            "relation": "isPartOf",
+            "resource_type":"dataset"
+        }
+    ]
+}


### PR DESCRIPTION
Once this is merged, it's gonna come public on Zenodo. The minimum metadata love the `.zenodo.json` should receive before merging is:

- correct license (now: CC0)
- relevant contributors
- relevant creators aka authors (current: Kirsten)

Optionally, the best keywords out there.

Experience shows it's best to use a JSON linter because as much as a trailing comma will cause Zenodo to reject the release. The full json-schema for the Zenodo API can be found [here](https://github.com/johentsch/metadata-schema-zenodo/blob/main/schema.json). Once adapted, please assign me to this PR and I'll take care of it.